### PR TITLE
default header-img when page does not define one

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 # Site settings
 title: Clean Blog
+header-img: img/home-bg.jpg
 email: your-email@yourdomain.com
 description: "Write your site description here. It will be used as your sites meta description as well!"
 baseurl: "/startbootstrap-clean-blog-jekyll"

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <!-- Page Header -->
-<header class="intro-header" style="background-image: url('{{ site.baseurl }}/{{ page.header-img }}')">
+<header class="intro-header" style="background-image: url('{{ site.baseurl }}/{% if page.header-img %}{{ page.header-img }}{% else %}{{ site.header-img }}{% endif %}')">
     <div class="container">
         <div class="row">
             <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <!-- Post Header -->
-<header class="intro-header" style="background-image: url('{{ site.baseurl }}/{{ page.header-img }}')">
+<header class="intro-header" style="background-image: url('{{ site.baseurl }}/{% if page.header-img %}{{ page.header-img }}{% else %}{{ site.header-img }}{% endif %}')">
     <div class="container">
         <div class="row">
             <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">

--- a/index.html
+++ b/index.html
@@ -1,14 +1,12 @@
 ---
 layout: page
 description: "A Clean Blog Theme by Start Bootstrap"
-header-img: "img/home-bg.jpg"
 ---
 
 {% for post in paginator.posts %}
 <div class="post-preview">
     <a href="{{ post.url | prepend: site.baseurl }}">
-        <h2 class="post-title">
-            {{ post.title }}
+        <h2 class="post-title">            {{ post.title }}
         </h2>
         {% if post.subtitle %}
         <h3 class="post-subtitle">


### PR DESCRIPTION
When you forget to set page.header-img the rendered page is not readable (white header on white bg). Also, in most cases (at least for me) I do not create a special post-bg-img.
So I define a site.header-img that is used as default.

This PR:
- _config with site.header-img
- index without page.header-img (proof)
- if statements in _layouts/(page|post).html
