### PR TITLE
Update less for .intro-header background-color

### DIFF
--- a/less/clean-blog.less
+++ b/less/clean-blog.less
@@ -157,8 +157,8 @@ hr.small {
 // Header
 
 .intro-header {
-	background-color: @gray; 
-	background: no-repeat center center; 
+	background: no-repeat center center;
+	background-color: @gray;
 	background-attachment: scroll;
 	.background-cover;
 	// NOTE: Background images are set within the HTML using inline CSS!


### PR DESCRIPTION
Changed the position of .intro-header {background-color: #808080;} right after the {background: no-repeat center center;}, so that .intro-header background-color will appear if the header-img not loaded.