### PR TITLE
Fix the not-really-clean <hr> post separators

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@ description: "A Clean Blog Theme by Start Bootstrap"
 ---
 
 {% for post in paginator.posts %}
+{{ DIVIDER }}
 <div class="post-preview">
     <a href="{{ post.url | prepend: site.baseurl }}">
         <h2 class="post-title">            {{ post.title }}
@@ -16,7 +17,7 @@ description: "A Clean Blog Theme by Start Bootstrap"
     </a>
     <p class="post-meta">Posted by {% if post.author %}{{ post.author }}{% else %}{{ site.title }}{% endif %} on {{ post.date | date: "%B %-d, %Y" }}</p>
 </div>
-<hr>
+{% assign DIVIDER = "<hr>" %}
 {% endfor %}
 
 <!-- Pager -->


### PR DESCRIPTION
This theme is so close to perfect! This last change cleans up one of the only "problems" (DIVIDER is "" until it is assigned). Specifically, this change solves the problem of an extra \<hr> after the final post in the index.