### PR TITLE
Add icon on navbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ A Grunt environment is also included. There are a number of tasks it performs li
 
 You can run `jekyll serve --watch` and `grunt watch` at the same time to watch for changes and then build them all at once.
 
+## Show nav icon
+You can use icon on navbar.  
+If `logoicon` is true, it shows icon instead of title text.  
+If you don't want to use page icon, remove `icon: ""` from each page.  
+Go to [Font-Awesome](http://fortawesome.github.io/Font-Awesome/icons/) for using icon.
+
+in *_config.yml*  
+`logoicon: [ true, "fa fa-rocket" ]`, using `fa fa-user` icon.  
+`homeicon: [ true, "fa fa-home" ]`, using `fa fa-home` icon. 
+
+
+
 ## Support
 
 Visit Clean Blog's template overview page on Start Bootstrap at http://startbootstrap.com/template-overviews/clean-blog/ and leave a comment, email feedback@startbootstrap.com, or open an issue here on GitHub for support.

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,10 @@ twitter_username: SBootstrap
 github_username:  davidtmiller
 facebook_username:  IronSummitMedia
 
+# Nav icon settings
+logoicon: [ true, "fa fa-rocket" ] # Logo icon of the navbar
+homeicon: [ true, "fa fa-home" ]   # Home icon of the navbar
+
 # Build settings
 markdown: kramdown
 highlighter: pygments

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -9,18 +9,24 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="{{ site.baseurl }}/">{{ site.title }}</a>
+            <a class="navbar-brand" href="{{ site.baseurl }}/">
+		{% if site.logoicon[0] %}
+		<i class="{{ site.logoicon[1] }}"></i>
+		{% else %}
+		{{ site.title }}
+		{% endif %}
+	    </a>
         </div>
 
         <!-- Collect the nav links, forms, and other content for toggling -->
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav navbar-right">
                 <li>
-                    <a href="{{ site.baseurl }}/">Home</a>
+				<a href="{{ site.baseurl }}/">{% if site.homeicon[0] %}<i class="{{ site.homeicon[1] }}"></i>&nbsp; {% endif %}Home</a>
                 </li>
                 {% for page in site.pages %}{% if page.title %}
                 <li>
-                    <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
+				<a href="{{ page.url | prepend: site.baseurl }}">{% if page.icon %}<i class="{{ page.icon }}"></i>&nbsp; {% endif %}{{ page.title }}</a>
                 </li>
                 {% endif %}{% endfor %}
             </ul>

--- a/about.html
+++ b/about.html
@@ -2,6 +2,7 @@
 layout: page
 title: "About"
 description: "This is what I do."
+icon: "fa fa-user"
 header-img: "img/about-bg.jpg"
 ---
 

--- a/contact.html
+++ b/contact.html
@@ -2,6 +2,7 @@
 layout: page
 title: "Contact"
 description: "Have questions? I have answers (maybe)."
+icon: "fa fa-globe"
 header-img: "img/contact-bg.jpg"
 ---
 


### PR DESCRIPTION
changed some codes that users can choose/switch between icon and title text.  
[View demo](http://cryptosan.github.io)  
- Add 'logoicon', and 'homeicon' in _config.yml, user can turn on/off them.  
  logoicon is a setting that can use icon instead of text title.    
  homeicon is a setting that can be next to Home text of navbar.  
- Add 'icon: ""' into each page (about.html, and contact.html), if a user doesn't wanna use icon, should remove the setting from each page.  

Theme is so cool :)   
Thank you!  